### PR TITLE
Add Strava webhook integration for real-time run tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
 	"main": "index.js",
 	"scripts": {
 		"start": "node dist/index.js",
+		"start:server": "node dist/server.js",
 		"build": "tsc",
 		"dev": "pnpm exec ts-node src/index.ts",
+		"dev:server": "pnpm exec ts-node src/server.ts",
 		"lint": "pnpm biome check",
 		"format": "pnpm biome format --write"
 	},

--- a/src/harvesters/index.ts
+++ b/src/harvesters/index.ts
@@ -2,10 +2,10 @@ import fetchGoodreadsActivity from "./goodreads";
 import fetchLetterboxdActivity from "./letterboxd";
 import fetchGitHubContributions from "./github";
 
-export type TracktorService = "goodreads" | "letterboxd" | "github";
+export type TracktorService = "goodreads" | "letterboxd" | "github" | "strava";
 
 export {
-  fetchGoodreadsActivity,
-  fetchLetterboxdActivity,
-  fetchGitHubContributions,
+	fetchGoodreadsActivity,
+	fetchLetterboxdActivity,
+	fetchGitHubContributions,
 };

--- a/src/harvesters/strava.ts
+++ b/src/harvesters/strava.ts
@@ -4,29 +4,29 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const { STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET, STRAVA_REFRESH_TOKEN } =
-  process.env;
+	process.env;
 
 if (!STRAVA_CLIENT_ID || !STRAVA_CLIENT_SECRET || !STRAVA_REFRESH_TOKEN) {
-  throw new Error("Missing required environment variables for Strava API.");
+	throw new Error("Missing required environment variables for Strava API.");
 }
 
-async function refreshAccessToken(): Promise<string> {
-  try {
-    const response = await axios.post("https://www.strava.com/oauth/token", {
-      client_id: STRAVA_CLIENT_ID,
-      client_secret: STRAVA_CLIENT_SECRET,
-      refresh_token: STRAVA_REFRESH_TOKEN,
-      grant_type: "refresh_token",
-    });
+export async function refreshAccessToken(): Promise<string> {
+	try {
+		const response = await axios.post("https://www.strava.com/oauth/token", {
+			client_id: STRAVA_CLIENT_ID,
+			client_secret: STRAVA_CLIENT_SECRET,
+			refresh_token: STRAVA_REFRESH_TOKEN,
+			grant_type: "refresh_token",
+		});
 
-    const { access_token, refresh_token: newRefreshToken } = response.data;
-    console.log(`New Refresh Token: ${newRefreshToken}`);
+		const { access_token, refresh_token: newRefreshToken } = response.data;
+		console.log(`New Refresh Token: ${newRefreshToken}`);
 
-    return access_token;
-  } catch (error) {
-    console.error("Error refreshing access token.");
-    throw new Error("Failed to refresh access token");
-  }
+		return access_token;
+	} catch (error) {
+		console.error("Error refreshing access token.");
+		throw new Error("Failed to refresh access token");
+	}
 }
 
 /**
@@ -37,37 +37,37 @@ async function refreshAccessToken(): Promise<string> {
  * our DB when the activity type is a run.
  */
 async function fetchStravaActivity({
-  before,
-  after,
-  page = 1,
-  per_page = 30,
+	before,
+	after,
+	page = 1,
+	per_page = 30,
 }: {
-  before?: number;
-  after?: number;
-  page?: number;
-  per_page?: number;
+	before?: number;
+	after?: number;
+	page?: number;
+	per_page?: number;
 } = {}) {
-  try {
-    const accessToken = await refreshAccessToken();
-    const params: Record<string, string | number> = {
-      page,
-      per_page,
-    };
-    if (before) params.before = before;
-    if (after) params.after = after;
+	try {
+		const accessToken = await refreshAccessToken();
+		const params: Record<string, string | number> = {
+			page,
+			per_page,
+		};
+		if (before) params.before = before;
+		if (after) params.after = after;
 
-    const response = await axios.get(
-      "https://www.strava.com/api/v3/athlete/activities",
-      {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        params,
-      }
-    );
+		const response = await axios.get(
+			"https://www.strava.com/api/v3/athlete/activities",
+			{
+				headers: { Authorization: `Bearer ${accessToken}` },
+				params,
+			},
+		);
 
-    console.log(JSON.stringify(response.data, null, 2));
-  } catch (error) {
-    console.error("Error fetching activities.");
-  }
+		console.log(JSON.stringify(response.data, null, 2));
+	} catch (error) {
+		console.error("Error fetching activities.");
+	}
 }
 
 export default fetchStravaActivity;

--- a/src/routes/strava-webhook.ts
+++ b/src/routes/strava-webhook.ts
@@ -1,0 +1,79 @@
+import { Router, type Request, type Response } from "express";
+import type { StravaWebhookEvent } from "../types/strava";
+import {
+	fetchActivityById,
+	isRunActivity,
+	getActivityYear,
+} from "../services/strava";
+import { writeTracktorCount } from "../utils/database";
+
+const router = Router();
+
+const STRAVA_VERIFY_TOKEN = process.env.STRAVA_VERIFY_TOKEN;
+
+/**
+ * GET /strava/webhook
+ * Handles Strava subscription validation requests
+ */
+router.get("/", (req: Request, res: Response) => {
+	const mode = req.query["hub.mode"];
+	const challenge = req.query["hub.challenge"];
+	const verifyToken = req.query["hub.verify_token"];
+
+	if (mode === "subscribe" && verifyToken === STRAVA_VERIFY_TOKEN) {
+		console.log("Strava webhook subscription validated");
+		res.json({ "hub.challenge": challenge });
+	} else {
+		console.error("Strava webhook validation failed");
+		res.status(403).send("Forbidden");
+	}
+});
+
+/**
+ * POST /strava/webhook
+ * Handles incoming Strava webhook events
+ * Responds immediately with 200, processes asynchronously
+ */
+router.post("/", (req: Request, res: Response) => {
+	const event = req.body as StravaWebhookEvent;
+
+	console.log("Received Strava webhook event:", JSON.stringify(event));
+
+	// Acknowledge receipt immediately
+	res.status(200).send("EVENT_RECEIVED");
+
+	// Process the event asynchronously
+	processWebhookEvent(event).catch((error) => {
+		console.error("Error processing Strava webhook event:", error);
+	});
+});
+
+/**
+ * Processes a Strava webhook event asynchronously
+ */
+async function processWebhookEvent(event: StravaWebhookEvent): Promise<void> {
+	// Only process activity creation events
+	if (event.object_type !== "activity" || event.aspect_type !== "create") {
+		console.log(`Ignoring event: ${event.object_type} ${event.aspect_type}`);
+		return;
+	}
+
+	try {
+		const activity = await fetchActivityById(event.object_id);
+		console.log(`Fetched activity: ${activity.name} (${activity.type})`);
+
+		if (!isRunActivity(activity)) {
+			console.log(`Activity is not a run (type: ${activity.type}), skipping`);
+			return;
+		}
+
+		const year = getActivityYear(activity);
+		await writeTracktorCount("strava", year, 1, "runs");
+		console.log(`Incremented Strava run count for ${year}`);
+	} catch (error) {
+		console.error(`Failed to process activity ${event.object_id}:`, error);
+		throw error;
+	}
+}
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,24 @@
+import express from "express";
+import dotenv from "dotenv";
+import stravaWebhookRouter from "./routes/strava-webhook";
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Middleware
+app.use(express.json());
+
+// Health check endpoint
+app.get("/health", (_req, res) => {
+	res.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+// Mount webhook routes
+app.use("/strava/webhook", stravaWebhookRouter);
+
+// Start server
+app.listen(PORT, () => {
+	console.log(`Tracktor webhook server running on port ${PORT}`);
+});

--- a/src/services/strava.ts
+++ b/src/services/strava.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { refreshAccessToken } from "../harvesters/strava";
+import type { StravaActivity } from "../types/strava";
+
+/**
+ * Fetches a single activity by ID from the Strava API
+ */
+export async function fetchActivityById(
+	activityId: number,
+): Promise<StravaActivity> {
+	const accessToken = await refreshAccessToken();
+
+	const response = await axios.get<StravaActivity>(
+		`https://www.strava.com/api/v3/activities/${activityId}`,
+		{
+			headers: { Authorization: `Bearer ${accessToken}` },
+		},
+	);
+
+	return response.data;
+}
+
+/**
+ * Checks if the activity type is a "Run"
+ */
+export function isRunActivity(activity: StravaActivity): boolean {
+	return activity.type === "Run";
+}
+
+/**
+ * Extracts the year from an activity's start date
+ */
+export function getActivityYear(activity: StravaActivity): number {
+	return new Date(activity.start_date).getFullYear();
+}

--- a/src/types/strava.ts
+++ b/src/types/strava.ts
@@ -1,0 +1,59 @@
+/**
+ * Strava webhook event payload structure
+ * Sent by Strava when an activity event occurs
+ */
+export interface StravaWebhookEvent {
+	/** Type of object (e.g., "activity") */
+	object_type: "activity" | "athlete";
+	/** ID of the activity or athlete */
+	object_id: number;
+	/** Type of action (e.g., "create", "update", "delete") */
+	aspect_type: "create" | "update" | "delete";
+	/** Athlete ID who owns the activity */
+	owner_id: number;
+	/** Subscription ID */
+	subscription_id: number;
+	/** Unix timestamp of the event */
+	event_time: number;
+	/** Updates object containing changed fields (for update events) */
+	updates?: Record<string, unknown>;
+}
+
+/**
+ * Strava activity response from the API
+ */
+export interface StravaActivity {
+	/** Unique activity ID */
+	id: number;
+	/** Activity name/title */
+	name: string;
+	/** Activity type (e.g., "Run", "Ride", "Swim") */
+	type: string;
+	/** Sport type for more specific categorization */
+	sport_type: string;
+	/** ISO 8601 timestamp of when the activity started */
+	start_date: string;
+	/** Local start date in athlete's timezone */
+	start_date_local: string;
+	/** Distance in meters */
+	distance: number;
+	/** Moving time in seconds */
+	moving_time: number;
+	/** Elapsed time in seconds */
+	elapsed_time: number;
+	/** Total elevation gain in meters */
+	total_elevation_gain: number;
+	/** Athlete who performed the activity */
+	athlete: {
+		id: number;
+	};
+}
+
+/**
+ * Strava webhook subscription validation query params
+ */
+export interface StravaWebhookValidation {
+	"hub.mode": string;
+	"hub.challenge": string;
+	"hub.verify_token": string;
+}


### PR DESCRIPTION
Implements webhook endpoint that receives Strava activity notifications, fetches activity details, and increments the run count in Supabase when a new run is completed. Replaces the need for OAuth-based polling.