### PR TITLE
Add GitHub language analytics feature

### DIFF
--- a/src/harvesters/github-languages.ts
+++ b/src/harvesters/github-languages.ts
@@ -1,0 +1,152 @@
+import axios from "axios";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const { GITHUB_TOKEN, GITHUB_USERNAME } = process.env;
+
+if (!GITHUB_TOKEN || !GITHUB_USERNAME) {
+  throw new Error(
+    "Missing GITHUB_TOKEN or GITHUB_USERNAME in environment variables."
+  );
+}
+
+export type LanguageStats = {
+  languageName: string;
+  bytes: number;
+  repoCount: number;
+  percentage: number;
+};
+
+type LanguageEdge = {
+  size: number;
+  node: {
+    name: string;
+  };
+};
+
+type RepositoryWithLanguages = {
+  name: string;
+  owner: {
+    login: string;
+  };
+  languages: {
+    edges: LanguageEdge[];
+    totalSize: number;
+  };
+};
+
+type ContributionsCollectionWithLanguages = {
+  totalCommitContributions: number;
+  commitContributionsByRepository: {
+    repository: RepositoryWithLanguages;
+    contributions: {
+      totalCount: number;
+    };
+  }[];
+};
+
+export async function fetchGitHubLanguages(
+  year: number,
+  fromDate?: string
+): Promise<LanguageStats[]> {
+  const from = fromDate ?? `${year}-01-01T00:00:00Z`;
+  const to = new Date().toISOString();
+
+  const query = `
+    query ($username: String!, $from: DateTime!, $to: DateTime!) {
+      user(login: $username) {
+        contributionsCollection(from: $from, to: $to) {
+          totalCommitContributions
+          commitContributionsByRepository {
+            repository {
+              name
+              owner { login }
+              languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
+                edges {
+                  size
+                  node { name }
+                }
+                totalSize
+              }
+            }
+            contributions { totalCount }
+          }
+        }
+      }
+    }
+  `;
+
+  const variables = {
+    username: GITHUB_USERNAME,
+    from,
+    to,
+  };
+
+  try {
+    const response = await axios.post(
+      "https://api.github.com/graphql",
+      { query, variables },
+      {
+        headers: {
+          Authorization: `Bearer ${GITHUB_TOKEN}`,
+        },
+      }
+    );
+
+    const data: ContributionsCollectionWithLanguages =
+      response.data.data.user.contributionsCollection;
+
+    return aggregateLanguages(data.commitContributionsByRepository);
+  } catch (error) {
+    console.error("Error fetching GitHub languages.");
+    throw error;
+  }
+}
+
+function aggregateLanguages(
+  repos: ContributionsCollectionWithLanguages["commitContributionsByRepository"]
+): LanguageStats[] {
+  const languageMap = new Map<
+    string,
+    { bytes: number; repos: Set<string> }
+  >();
+
+  let totalBytes = 0;
+
+  for (const { repository } of repos) {
+    const repoKey = `${repository.owner.login}/${repository.name}`;
+
+    for (const edge of repository.languages.edges) {
+      const langName = edge.node.name;
+      const size = edge.size;
+
+      if (!languageMap.has(langName)) {
+        languageMap.set(langName, { bytes: 0, repos: new Set() });
+      }
+
+      const lang = languageMap.get(langName)!;
+      lang.bytes += size;
+      lang.repos.add(repoKey);
+      totalBytes += size;
+    }
+  }
+
+  const stats: LanguageStats[] = [];
+
+  for (const [languageName, { bytes, repos }] of languageMap) {
+    stats.push({
+      languageName,
+      bytes,
+      repoCount: repos.size,
+      percentage:
+        totalBytes > 0
+          ? Math.round((bytes / totalBytes) * 10000) / 100
+          : 0,
+    });
+  }
+
+  return stats.sort((a, b) => b.bytes - a.bytes);
+}
+
+export default fetchGitHubLanguages;

--- a/src/harvesters/github.ts
+++ b/src/harvesters/github.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import dotenv from "dotenv";
+import { fetchGitHubLanguages, type LanguageStats } from "./github-languages";
 
 dotenv.config();
 
@@ -26,6 +27,11 @@ type ContributionsCollection = {
       totalCount: number;
     };
   }[];
+};
+
+export type GitHubData = {
+  contributions: { totalCommits: number; repositoryCount: number } | null;
+  languages: LanguageStats[] | null;
 };
 
 /**
@@ -97,6 +103,22 @@ async function fetchGitHubContributions(year: number, lastUpdated?: string) {
     console.error("Error fetching GitHub contributions.");
     throw error;
   }
+}
+
+export async function fetchGitHubData(
+  year: number,
+  lastUpdated?: string
+): Promise<GitHubData> {
+  const [contributions, languages] = await Promise.allSettled([
+    fetchGitHubContributions(year, lastUpdated),
+    fetchGitHubLanguages(year),
+  ]);
+
+  return {
+    contributions:
+      contributions.status === "fulfilled" ? contributions.value : null,
+    languages: languages.status === "fulfilled" ? languages.value : null,
+  };
 }
 
 export default fetchGitHubContributions;

--- a/src/harvesters/index.ts
+++ b/src/harvesters/index.ts
@@ -1,6 +1,7 @@
 import fetchGoodreadsActivity from "./goodreads";
 import fetchLetterboxdActivity from "./letterboxd";
-import fetchGitHubContributions from "./github";
+import fetchGitHubContributions, { fetchGitHubData, type GitHubData } from "./github";
+import fetchGitHubLanguages, { type LanguageStats } from "./github-languages";
 
 export type TracktorService = "goodreads" | "letterboxd" | "github" | "strava";
 
@@ -8,4 +9,8 @@ export {
 	fetchGoodreadsActivity,
 	fetchLetterboxdActivity,
 	fetchGitHubContributions,
+	fetchGitHubData,
+	fetchGitHubLanguages,
 };
+
+export type { GitHubData, LanguageStats };

--- a/src/scripts/backfill-languages.ts
+++ b/src/scripts/backfill-languages.ts
@@ -1,0 +1,34 @@
+import { fetchGitHubLanguages } from "../harvesters/github-languages";
+import { writeLanguageSnapshot } from "../utils/language-database";
+
+async function backfillLanguages() {
+  console.log("Starting language backfill...");
+
+  const year = 2026;
+  const fromDate = "2026-01-01T00:00:00Z";
+
+  try {
+    console.log(`Fetching language data from ${fromDate}...`);
+    const languages = await fetchGitHubLanguages(year, fromDate);
+
+    if (languages.length === 0) {
+      console.log("No language data found.");
+      return;
+    }
+
+    console.log(`Found ${languages.length} languages. Writing snapshot...`);
+    await writeLanguageSnapshot(languages, year);
+
+    console.log("\nBackfill complete! Language breakdown:");
+    for (const lang of languages.slice(0, 10)) {
+      console.log(
+        `  ${lang.languageName}: ${lang.percentage}% (${lang.bytes} bytes across ${lang.repoCount} repos)`
+      );
+    }
+  } catch (error) {
+    console.error("Backfill failed:", error);
+    process.exit(1);
+  }
+}
+
+backfillLanguages();

--- a/src/tracktor.ts
+++ b/src/tracktor.ts
@@ -1,21 +1,26 @@
 import {
   fetchGoodreadsActivity,
   fetchLetterboxdActivity,
-  fetchGitHubContributions,
+  fetchGitHubData,
+  type GitHubData,
 } from "./harvesters";
 import type { TracktorService } from "./harvesters";
 import { getLastUpdatedFromDB, writeTracktorCount } from "./utils/database";
+import { writeLanguageSnapshot } from "./utils/language-database";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
 
 interface Service {
   name: TracktorService;
-  fetch: () => Promise<
-    number | { totalCommits: number; repositoryCount: number }
-  >;
+  fetch: () => Promise<number | GitHubData>;
   key: string;
   activityTypes: { name: string; getCount?: (data: any) => number }[];
 }
-
-type GitHubActivity = Awaited<ReturnType<typeof fetchGitHubContributions>>;
 
 /**
  * Fetches activity data from various services and writes the counts to the database.
@@ -47,31 +52,31 @@ async function tracktor() {
     },
     {
       name: "github",
-      fetch: () => fetchGitHubContributions(currentYear, lastGitHubUpdate ?? ""),
+      fetch: () => fetchGitHubData(currentYear, lastGitHubUpdate ?? ""),
       key: "github",
       activityTypes: [
         {
           name: "commits",
-          getCount: (data: GitHubActivity) => data.totalCommits,
+          getCount: (data: GitHubData) => data.contributions?.totalCommits ?? 0,
         },
         {
           name: "repositories",
-          getCount: (data: GitHubActivity) => data.repositoryCount,
+          getCount: (data: GitHubData) => data.contributions?.repositoryCount ?? 0,
         },
       ],
     },
   ];
 
   type Totals = {
-    [key: string]: number | { totalCommits: number; repositoryCount: number };
+    [key: string]: number | GitHubData;
   };
 
   const totals: Totals = {
     letterboxd: 0,
     goodreads: 0,
     github: {
-      totalCommits: 0,
-      repositoryCount: 0,
+      contributions: { totalCommits: 0, repositoryCount: 0 },
+      languages: null,
     },
   };
 
@@ -86,21 +91,38 @@ async function tracktor() {
 
         await writeTracktorCount(service.name, currentYear, count, activityType.name);
       }
+
+      if (service.name === "github") {
+        const githubResult = result as GitHubData;
+        if (githubResult.languages && githubResult.languages.length > 0) {
+          await writeLanguageSnapshot(githubResult.languages, currentYear);
+        }
+      }
     } catch (error) {
       console.error(`Error fetching ${service.name} activity.`);
       console.error(error);
     }
   }
 
+  const githubData = totals.github as GitHubData;
+  const commits = githubData.contributions?.totalCommits ?? 0;
+  const repos = githubData.contributions?.repositoryCount ?? 0;
+
   console.log(
     `📚 Goodreads: ${totals.goodreads} new books read since the last run.
   🎥 Letterboxd: ${totals.letterboxd} new movies watched since the last run.
-  💻 GitHub: ${
-    typeof totals.github === "object" ? totals.github.totalCommits : 0
-  } new commits across ${
-      typeof totals.github === "object" ? totals.github.repositoryCount : 0
-    } repositories since the last run.`
+  💻 GitHub: ${commits} new commits across ${repos} repositories since the last run.`
   );
+
+  if (githubData.languages && githubData.languages.length > 0) {
+    console.log("\nGitHub Languages:");
+    for (const lang of githubData.languages.slice(0, 10)) {
+      const bytesFormatted = formatBytes(lang.bytes);
+      console.log(
+        `  ${lang.languageName}: ${lang.percentage}% (${bytesFormatted} across ${lang.repoCount} repos)`
+      );
+    }
+  }
 
   console.log(`👨🏻‍🌾 Tracktor finished at ${new Date().toISOString()} 🚜!`);
   return;

--- a/src/utils/language-database.ts
+++ b/src/utils/language-database.ts
@@ -1,0 +1,72 @@
+import { supabase } from "./supabase-client";
+
+export type LanguageStats = {
+  languageName: string;
+  bytes: number;
+  repoCount: number;
+  percentage: number;
+};
+
+export async function writeLanguageSnapshot(
+  languages: LanguageStats[],
+  year: number
+): Promise<void> {
+  const snapshotDate = new Date().toISOString().split("T")[0];
+
+  const rows = languages.map((lang) => ({
+    snapshot_date: snapshotDate,
+    year,
+    language_name: lang.languageName,
+    bytes: lang.bytes,
+    repo_count: lang.repoCount,
+    percentage: lang.percentage,
+  }));
+
+  const { error } = await supabase
+    .from("github_language_stats")
+    .upsert(rows, { onConflict: "snapshot_date,language_name" });
+
+  if (error) {
+    console.error("Error writing language snapshot:", error);
+    throw error;
+  }
+
+  console.log(
+    `✅ Wrote language snapshot for ${snapshotDate}: ${languages.length} languages`
+  );
+}
+
+export async function getLatestLanguageSnapshot(): Promise<LanguageStats[]> {
+  const { data: latestDate, error: dateError } = await supabase
+    .from("github_language_stats")
+    .select("snapshot_date")
+    .order("snapshot_date", { ascending: false })
+    .limit(1)
+    .single();
+
+  if (dateError) {
+    if (dateError.code === "PGRST116") {
+      return [];
+    }
+    console.error("Error fetching latest snapshot date:", dateError);
+    throw dateError;
+  }
+
+  const { data, error } = await supabase
+    .from("github_language_stats")
+    .select("language_name, bytes, repo_count, percentage")
+    .eq("snapshot_date", latestDate.snapshot_date)
+    .order("bytes", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching latest language snapshot:", error);
+    throw error;
+  }
+
+  return data.map((row) => ({
+    languageName: row.language_name,
+    bytes: row.bytes,
+    repoCount: row.repo_count,
+    percentage: row.percentage,
+  }));
+}

--- a/supabase/migrations/20260321000000_create_github_language_stats.sql
+++ b/supabase/migrations/20260321000000_create_github_language_stats.sql
@@ -1,0 +1,21 @@
+-- Create github_language_stats table for storing language analytics snapshots
+CREATE TABLE github_language_stats (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  snapshot_date DATE NOT NULL,
+  year INTEGER NOT NULL,
+  language_name VARCHAR(100) NOT NULL,
+  bytes BIGINT NOT NULL,
+  repo_count INTEGER NOT NULL,
+  percentage DECIMAL(5,2),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(snapshot_date, language_name)
+);
+
+-- Index for querying by date (most common query pattern)
+CREATE INDEX idx_language_stats_date ON github_language_stats(snapshot_date DESC);
+
+-- Index for filtering by year
+CREATE INDEX idx_language_stats_year ON github_language_stats(year);
+
+-- Index for filtering by language
+CREATE INDEX idx_language_stats_language ON github_language_stats(language_name);


### PR DESCRIPTION
## Summary
- Fetches aggregate language data from repos contributed to via GitHub GraphQL API
- Runs in parallel with existing contributions query using `Promise.allSettled`
- Stores daily snapshots in new `github_language_stats` table for trend analysis

## Changes
- `src/harvesters/github-languages.ts` - Language fetching and aggregation logic
- `src/utils/language-database.ts` - Database operations for snapshots
- `src/harvesters/github.ts` - Added `fetchGitHubData()` for parallel fetching
- `src/tracktor.ts` - Integrated language stats into main flow with console output
- `src/scripts/backfill-languages.ts` - One-time backfill script
- `supabase/migrations/` - SQL migration for new table

## Test plan
- [x] Run SQL migration in Supabase
- [x] Run backfill script: `npx ts-node src/scripts/backfill-languages.ts`
- [x] Run full tracktor: `npx ts-node src/index.ts`
- [x] Verify language snapshot written to `github_language_stats` table
- [x] Verify console output shows language breakdown